### PR TITLE
Add ga-beacon

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,9 @@
         <p>また、当サービスは、平成30年4月3日現在の情報によっています。</p>
       </div>
     </div>
+    <a href="https://moneyforward.github.io/tax_newurl/">
+        <img src="https://ga-beacon.appspot.com/UA-36943659-46/moneyforward.github.io/tax_newurl/?pixel" />
+    </a>
   </body>
   <script type="text/javascript" src="./index.js"></script>
 </html>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
       </div>
     </div>
     <a href="https://moneyforward.github.io/tax_newurl/">
-        <img src="https://ga-beacon.appspot.com/UA-36943659-46/moneyforward.github.io/tax_newurl/?pixel" />
+      <img src="https://ga-beacon.appspot.com/UA-36943659-46/moneyforward.github.io/tax_newurl/?pixel" />
     </a>
   </body>
   <script type="text/javascript" src="./index.js"></script>


### PR DESCRIPTION
## これ何
アクセス数計測用に ga-beaconを設定する。

## 補足

![image1](https://ga-beacon.appspot.com/UA-36943659-46/moneyforward.github.io/tax_newurl/)

見えない様に小さくしていますが、この画像が埋め込まれます！

## 参考
GitHub Pagesでga-beaconを使ってリアルタイムアクセス解析 - Qiita https://qiita.com/kabayan55/items/f15c822939b2ab7dba35

[igrigorik/ga\-beacon: Google Analytics collector\-as\-a\-service \(using GA measurement protocol\)\.](https://github.com/igrigorik/ga-beacon)